### PR TITLE
adds jupyter support to pysmurf docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     python3-matplotlib \
  && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install scipy pandas pyyaml seaborn
+RUN pip3 install scipy pandas pyyaml seaborn jupyter
 
 WORKDIR /usr/local/src
 RUN git clone https://github.com/slaclab/pysmurf.git -b v3.1.3
@@ -32,5 +32,9 @@ ENV EPICS_PREFIX "smurf_server"
 
 # Set GTK3Agg as the matplotlib backend
 ENV MPLBACKEND GTK3Agg
+
+# Set jupyter config stuff
+COPY jupyter /etc/jupyter
+ENV JUPYTER_CONFIG_DIR /etc/jupyter
 
 ENTRYPOINT ["pysmurf_startup.sh"]

--- a/jupyter/jupyter_config.py
+++ b/jupyter/jupyter_config.py
@@ -1,0 +1,11 @@
+import os
+from notebook.auth import passwd
+
+c.NotebookApp.ip = '0.0.0.0'
+c.NotebookApp.port = int(os.environ.get("JUPYTER_PORT", 8888))
+
+c.NotebookApp.allow_root = True
+c.NotebookApp.open_browser = False
+
+c.NotebookApp.password = passwd(os.environ.get("JUPYTER_PW", 'password'))
+c.NotebookApp.password_required = True


### PR DESCRIPTION
There's an [issue](https://github.com/slaclab/pysmurf/issues/111) about setting up pysmurf docker with jupyter. Before I was building a separate docker with jupyter support, but it's probably better to put it here by default.

To run you just need to set the entrypoint to `jupyter notebook`, and you can set the `JUPYTER_PW` and `JUPYTER_PORT` environment variables to specify password and port to run on. Example docker-compose entry:

```
    jupyter:
        image: pysmurf
        ports:
            - 8888:8888
        environment:
            JUPYTER_PW: abcd
            JUPYTER_PORT: 8888
        entrypoint: jupyter notebook
```
